### PR TITLE
Minecraft 1.16.x 지원

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 // Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
 compileJava.options.encoding = 'UTF-8'
-version = '1.16.3-0.7.1'
+version = '1.16.4-0.7.1'
 group = 'kr.neko.sokcuri.naraechat' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'naraechat'
 
@@ -37,7 +37,7 @@ minecraft {
     // stable_#            Stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'snapshot', version: '20200916-1.16.2'
+    mappings channel: 'snapshot', version: '20201028-1.16.3'
     // makeObfSourceJar false // an Srg named sources jar is made by default. uncomment this to disable.
     
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -66,7 +66,7 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.16.3-34.1.0'
+    minecraft 'net.minecraftforge:forge:1.16.4-35.1.4'
     compile 'net.java.dev.jna:jna:4.1.0'
     compile 'net.java.dev.jna:jna-platform:4.1.0'
     compile 'org.apache.commons:commons-text:1.7'

--- a/build.gradle
+++ b/build.gradle
@@ -70,10 +70,6 @@ dependencies {
     compile 'net.java.dev.jna:jna:4.1.0'
     compile 'net.java.dev.jna:jna-platform:4.1.0'
     compile 'org.apache.commons:commons-text:1.7'
-    embed 'org.apache.pdfbox:fontbox:2.0.16'
-    embed group: 'org.apache.pdfbox', name: 'fontbox', version: '2.0.16'
-    embed 'org.ini4j:ini4j:0.5.1'
-    embed group: 'org.ini4j', name: 'ini4j', version: '0.5.1'
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 // Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
 compileJava.options.encoding = 'UTF-8'
-version = '1.16.1-0.7.1'
+version = '1.16.3-0.7.1'
 group = 'kr.neko.sokcuri.naraechat' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'naraechat'
 
@@ -37,7 +37,7 @@ minecraft {
     // stable_#            Stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'snapshot', version: '20200707-1.16.1'
+    mappings channel: 'snapshot', version: '20200916-1.16.2'
     // makeObfSourceJar false // an Srg named sources jar is made by default. uncomment this to disable.
     
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -66,7 +66,7 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.16.1-32.0.47'
+    minecraft 'net.minecraftforge:forge:1.16.3-34.1.0'
     compile 'net.java.dev.jna:jna:4.1.0'
     compile 'net.java.dev.jna:jna-platform:4.1.0'
     compile 'org.apache.commons:commons-text:1.7'

--- a/src/main/java/kr/neko/sokcuri/naraechat/Keyboard/Hangul_Set_2_Layout.java
+++ b/src/main/java/kr/neko/sokcuri/naraechat/Keyboard/Hangul_Set_2_Layout.java
@@ -351,9 +351,9 @@ public class Hangul_Set_2_Layout implements KeyboardLayout {
             if (cursorPosition == 0) return;
             if (trimStr.length() == 0) return;
             if (specifiedOffset == 0 || specifiedOffset - 1 >= trimStr.length()) return;
-            int startX = x + ObfuscatedMethod.$FontRenderer.getStringWidth.invoke(fontRenderer, trimStr.substring(0, specifiedOffset - 1));
+            int startX = x + fontRenderer.getStringWidth(trimStr.substring(0, specifiedOffset - 1));
             int startY = y - 1;
-            int endX = x + ObfuscatedMethod.$FontRenderer.getStringWidth.invoke(fontRenderer, trimStr.substring(0, specifiedOffset)) - 1;
+            int endX = x + fontRenderer.getStringWidth(trimStr.substring(0, specifiedOffset)) - 1;
             int endY = y + 1 + 9;
             drawAssembleCharBox(startX, startY, endX, endY, x, width);
         } else {

--- a/src/main/java/kr/neko/sokcuri/naraechat/NaraeChat.java
+++ b/src/main/java/kr/neko/sokcuri/naraechat/NaraeChat.java
@@ -12,6 +12,8 @@ import net.minecraft.client.gui.screen.ControlsScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.client.util.InputMappings;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.client.settings.KeyModifier;
 import net.minecraftforge.common.MinecraftForge;
@@ -33,6 +35,7 @@ import static org.lwjgl.glfw.GLFW.*;
 
 // The value here should match an entry in the META-INF/mods.toml file
 @Mod("naraechat")
+@OnlyIn(Dist.CLIENT)
 public final class NaraeChat
 {
     private static KeyboardLayout keyboard = Hangul_Set_2_Layout.getInstance();

--- a/src/main/java/kr/neko/sokcuri/naraechat/Obfuscated/ObfuscatedMethod.java
+++ b/src/main/java/kr/neko/sokcuri/naraechat/Obfuscated/ObfuscatedMethod.java
@@ -27,24 +27,6 @@ public final class ObfuscatedMethod<O, R> {
         }
     }
 
-    public static class $Widget {
-        public static final ObfuscatedMethod<Widget, Integer> getWidth;
-        public static final ObfuscatedMethod<Widget, Boolean> isFocused;
-
-        static {
-            getWidth        = new ObfuscatedMethod("getWidth", "func_230998_h_", Widget.class, Integer.class);
-            isFocused       = new ObfuscatedMethod("isFocused", "func_230999_j_", Widget.class, Boolean.class);
-        }
-    }
-
-    public static class $FontRenderer {
-        public static final ObfuscatedMethod<FontRenderer, Integer> getStringWidth;
-
-        static {
-            getStringWidth        = new ObfuscatedMethod("getStringWidth", "func_78256_a", FontRenderer.class, Integer.class, new Class<?>[] { String.class });
-        }
-    }
-
     public ObfuscatedMethod(String deobfName, String obfName, Class<O> owner, Class<R> retClass, Class<?>... parameters) {
         this.deobfName = deobfName;
         this.obfName = obfName;

--- a/src/main/java/kr/neko/sokcuri/naraechat/Wrapper/TextFieldWidgetWrapper.java
+++ b/src/main/java/kr/neko/sokcuri/naraechat/Wrapper/TextFieldWidgetWrapper.java
@@ -67,9 +67,7 @@ public class TextFieldWidgetWrapper implements TextComponentWrapper {
         return base.y;
     }
 
-    public int getHeight() {
-        return base.getHeight();
-    }
+    public int getHeight() { return base.getHeightRealms(); }
 
     public int getAdjustedWidth() {
         return base.getAdjustedWidth();

--- a/src/main/java/kr/neko/sokcuri/naraechat/Wrapper/TextFieldWidgetWrapper.java
+++ b/src/main/java/kr/neko/sokcuri/naraechat/Wrapper/TextFieldWidgetWrapper.java
@@ -67,7 +67,9 @@ public class TextFieldWidgetWrapper implements TextComponentWrapper {
         return base.y;
     }
 
-    public int getHeight() { return base.getHeightRealms(); }
+    public int getHeight() {
+        return base.getHeightRealms();
+    }
 
     public int getAdjustedWidth() {
         return base.getAdjustedWidth();
@@ -117,7 +119,7 @@ public class TextFieldWidgetWrapper implements TextComponentWrapper {
     }
 
     public boolean getVisible() {
-        return this.getVisible();
+        return base.getVisible();
     }
 
     @Override

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -20,6 +20,6 @@ description="나래챗은 마인크래프트 한글 입력을 도와줍니다. b
 [[dependencies.naraechat]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.16,)"
+    versionRange="[1.16,1.17)"
     ordering="NONE"
     side="BOTH"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[28,)"
+loaderVersion="[32,)"
 issueTrackerURL="https://github.com/sokcuri/naraechat/issues"
 license="GNU Lesser General Public License v3.0"
 [[mods]]
@@ -14,12 +14,12 @@ description="나래챗은 마인크래프트 한글 입력을 도와줍니다. b
 [[dependencies.naraechat]] #
     modId="forge"
     mandatory=true
-    versionRange="[28,)"
+    versionRange="[32,)"
     ordering="NONE"
     side="BOTH"
 [[dependencies.naraechat]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.16.3]"
+    versionRange="[1.16,)"
     ordering="NONE"
     side="BOTH"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,6 +1,7 @@
 modLoader="javafml"
 loaderVersion="[28,)"
 issueTrackerURL="https://github.com/sokcuri/naraechat/issues"
+license="GNU Lesser General Public License v3.0"
 [[mods]]
 modId="naraechat"
 version="${file.jarVersion}"
@@ -19,6 +20,6 @@ description="나래챗은 마인크래프트 한글 입력을 도와줍니다. b
 [[dependencies.naraechat]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.16.1]"
+    versionRange="[1.16.3]"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
* Forge 업데이트 (--1.16.3-34.1.0-- 1.16.4-35.1.4, Latest stable)
* 현재 제공되는 최신버전의 매핑 사용 (snapshot 20201028-1.16.3)
     - `TextFieldWidget.getHeight()` 대신 `TextFieldWidget.getHeightRealms()` 사용
     - 기존 마인크래프트 내에서 지원 안하던 메소드지만 Forge에서 자체 지원하다가, 공식적으로 추가되면서 현 매핑에서 `Realms`가 붙었다고 합니다.
* `mods.toml`에 License 필드 추가 (1.16.3 부터 필수)
<br/>

* 새 매핑적용으로 Public 메소드를 ObfuscatedMethod 에서 제거
   - 현재 남아있는 것들은 Private만 있습니다. SRG 변경 없음 확인.
   - PS. 새 매핑내 필드 중에서 `cursorPosition`은 `endIndex`, `cursorPosition2` 는 `startIndex`라고 기제됨을 확인했습니다.
<br/>

* 1.16.x 전버전에서 구동 가능하도록 변경 (Closes #17)
    - `TextFieldWidget.getHeightRealms()` 부분이 1.16에서 추가된걸로 확인되었고, 그외 다른 코드 변경이 없어 가능합니다.
    - `1.16.1-0.7.1` 이 신버전에서 사용 불가한 이유는 License 필드 의무화 및 `TextFieldWidget.getHeight()` 가 Forge에서 삭제, 모드에서 1.16.1 버전 강제 지정 등으로 불가능했던걸로 보입니다.
    - 각 마인크래프트 버전의 변동사항이 적어 Forge 랑 매핑 버전에 상관없이 구동 가능합니다.
<br/>

* 클라이언트 전용 모드로 (재)설정
    - 8493a56db414c4228b72ef9af67801c7b534bf58 에서 추가된 기능이지만, 코드 간소화(f704936e3752ddfa00d949d7917c8800145efa33)시 삭제되었기에 다시 설정합니다.
<br/>

* 현재 필요없는 Embed 라이브러리 제거
   - 구버전에서 폰트 변경 기능에 사용되던 라이브러리로 보이나 현재는 사용하지 않으므로 제거하였습니다.
   - 1,715KB -> 38KB (약 98% 절약)
   - PS. Forge 자체에서도 Config 기능을 지원합니다. (TOML로 저장됨). 다만 공식 문서에는 제대로 기제되있지 않아서 다른 코드를 찾아봐야합니다.

<br/>
커밋량이 많아졌으므로, Merge 시 Squash로 부탁드립니다.